### PR TITLE
Distortion taper

### DIFF
--- a/Assets/Prefabs/Effects/DistortionSphereDemo.prefab
+++ b/Assets/Prefabs/Effects/DistortionSphereDemo.prefab
@@ -1,0 +1,95 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1415353951321070838
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1415353951321070839}
+  - component: {fileID: 1415353951321070826}
+  - component: {fileID: 1415353951321070825}
+  - component: {fileID: 1415353951321070824}
+  m_Layer: 0
+  m_Name: DistortionSphereDemo
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1415353951321070839
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1415353951321070838}
+  m_LocalRotation: {x: 0.7071068, y: 0, z: 0, w: 0.7071068}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 10, y: 10, z: 10}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 90, y: 0, z: 0}
+--- !u!33 &1415353951321070826
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1415353951321070838}
+  m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &1415353951321070825
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1415353951321070838}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: db7b0c83f827eee4b8dc10bcbcf359b5, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!135 &1415353951321070824
+SphereCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1415353951321070838}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 0.5
+  m_Center: {x: 0, y: 0, z: 0}

--- a/Assets/Prefabs/Effects/DistortionSphereDemo.prefab.meta
+++ b/Assets/Prefabs/Effects/DistortionSphereDemo.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: d93071bf6da982441a63d38bdc0de51f
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/RenderDepth.cs
+++ b/Assets/RenderDepth.cs
@@ -1,0 +1,13 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+[ExecuteInEditMode]
+public class RenderDepth : MonoBehaviour
+{
+    void OnEnable()
+    {
+        // Makes depth texture accessible in shader
+        GetComponent<Camera>().depthTextureMode = DepthTextureMode.DepthNormals;
+    }
+}

--- a/Assets/RenderDepth.cs.meta
+++ b/Assets/RenderDepth.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 850602ca48640dd409151f589f3cb8ee
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/Demo.unity
+++ b/Assets/Scenes/Demo.unity
@@ -2121,6 +2121,24 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1571201838}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &259907146 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 2935614980997301576, guid: 3b04d644529aea34f9d8aac8a6196d7d,
+    type: 3}
+  m_PrefabInstance: {fileID: 732831621}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &259907147
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 259907146}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 850602ca48640dd409151f589f3cb8ee, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &262615409
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -6137,6 +6155,11 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 2935614980997301578, guid: 3b04d644529aea34f9d8aac8a6196d7d,
+        type: 3}
+      propertyPath: m_RenderingPath
+      value: -1
+      objectReference: {fileID: 0}
     - target: {fileID: 9115404474587516144, guid: 3b04d644529aea34f9d8aac8a6196d7d,
         type: 3}
       propertyPath: m_LocalPosition.x

--- a/Assets/Shaders/WaveDistortion.shader
+++ b/Assets/Shaders/WaveDistortion.shader
@@ -2,8 +2,8 @@
 {
     Properties
     {
-        _Strength("Distort Strength", Range(0, 1)) = 0.15
         _Noise("Noise Texture", 2D) = "white" {}
+        _Strength("Distort Strength", Range(0, 1)) = 0.15
         _Speed("Distort Speed", float) = 100
     }
 
@@ -28,41 +28,73 @@
 			#include "UnityCG.cginc"
 
             sampler2D _BackgroundTexture;
-            sampler2D _StrengthFilter;
             sampler2D _Noise;
             float _Strength;
             float _Speed;
 
+            sampler2D _CameraDepthNormalsTexture;
+
             struct vertexInput
             {
-                float4 vertex: POSITION;
-                float4 texCoord: TEXCOORD0;
+                float4 vertex: POSITION;    // Position of vertex in the world
+                float4 texCoord: TEXCOORD0; // Texture coordinates at the vertex
+                float3 normal: NORMAL;      // Normal vector at that point
             };
 
             struct vertexOutput
             {
-                float4 pos: SV_POSITION;
-                float4 grabPos: TEXCOORD0;
+                float4 pos: SV_POSITION;                  // Position in clip space
+                float4 preDistortionPosition: TEXCOORD0;  // Actual position on-screen
+                float4 postDistortionPosition: TEXCOORD1; // Position on-screen to actually grab from 
+                float4 depth: DEPTH;                      // Depth
+                float3 normal: NORMAL;
+                float3 viewDir: TEXCOORD2;
             };
 
             vertexOutput vert(vertexInput input)
             {
                 vertexOutput output;
-                
+
+                // Get position in clip space
                 output.pos = UnityObjectToClipPos(input.vertex);
-                output.grabPos = ComputeGrabScreenPos(output.pos);
 
+                // Get position on screen
+                output.preDistortionPosition = ComputeGrabScreenPos(output.pos);
+
+                // Get position on screen post distortion
+                output.postDistortionPosition = output.preDistortionPosition;
                 float noise = tex2Dlod(_Noise, input.texCoord).rgb;
+                output.postDistortionPosition.x += cos(noise * _Time.x * _Speed) * _Strength;
+                output.postDistortionPosition.y += sin(noise * _Time.x * _Speed) * _Strength;
 
-                output.grabPos.x += cos(noise * _Time.x * _Speed) * _Strength;
-                output.grabPos.y += sin(noise * _Time.x * _Speed) * _Strength;
-                
+                // Get depth
+                output.depth = UnityObjectToViewPos(input.vertex).z * _ProjectionParams.w;
+                //output.depth = -mul(UNITY_MATRIX_MV, input.vertex).z * _ProjectionParams.w;
+
+                // Get normal
+                output.normal = UnityObjectToWorldNormal(input.normal);
+
+                // Get view direction
+                output.viewDir = normalize(UnityWorldSpaceViewDir(mul(unity_ObjectToWorld, input.vertex)));
+
                 return output;
             }
 
             float4 frag(vertexOutput input) : COLOR
             {
-                return tex2Dproj(_BackgroundTexture, input.grabPos);
+                // Re-obtain the distortion in x and y directions
+                float xDisplacement = input.postDistortionPosition.x - input.preDistortionPosition.x;
+                float yDisplacement = input.postDistortionPosition.y - input.preDistortionPosition.y;
+
+                // Attenuation factor to simulate tapering towards the rim
+                float rim = abs(dot(input.normal, normalize(input.viewDir)));
+
+                float4 fragmentToGrab = input.preDistortionPosition;
+                fragmentToGrab.x += xDisplacement * rim;
+                fragmentToGrab.y += yDisplacement * rim;
+
+                // Grab the fragment from the background texture
+                return tex2Dproj(_BackgroundTexture, fragmentToGrab);
             }
 
         ENDCG

--- a/Assets/Shaders/WaveDistortion.shader
+++ b/Assets/Shaders/WaveDistortion.shader
@@ -46,7 +46,7 @@
                 float4 pos: SV_POSITION;                  // Position in clip space
                 float4 preDistortionPosition: TEXCOORD0;  // Actual position on-screen
                 float4 postDistortionPosition: TEXCOORD1; // Position on-screen to actually grab from 
-                float4 depth: DEPTH;                      // Depth
+                float4 depth: DEPTH;
                 float3 normal: NORMAL;
                 float3 viewDir: TEXCOORD2;
             };
@@ -69,7 +69,6 @@
 
                 // Get depth
                 output.depth = UnityObjectToViewPos(input.vertex).z * _ProjectionParams.w;
-                //output.depth = -mul(UNITY_MATRIX_MV, input.vertex).z * _ProjectionParams.w;
 
                 // Get normal
                 output.normal = UnityObjectToWorldNormal(input.normal);


### PR DESCRIPTION
- Updated WaveDistortion shader so that it tapers towards the edges of the object (works best on curved meshes like Spheres).
- Added DistortionSphereDemo prefab (under Effects folder)
- Added RenderDepth script so that WaveDistortion Shader can be passed the depth and normal texture from the camera